### PR TITLE
Pass thru X-Broker-Api-Version header to backend broker

### DIFF
--- a/apiclient/open_service_broker.go
+++ b/apiclient/open_service_broker.go
@@ -13,18 +13,20 @@ import (
 
 // OpenServiceBroker is the client struct for connecting to remote Open Service Broker API
 type OpenServiceBroker struct {
-	url      string
-	username string
-	password string
-	catalog  *brokerapi.CatalogResponse
+	url        string
+	username   string
+	password   string
+	catalog    *brokerapi.CatalogResponse
+	apiVersion string
 }
 
 // NewOpenServiceBroker constructs OpenServiceBroker
-func NewOpenServiceBroker(url, client, clientSecret string) *OpenServiceBroker {
+func NewOpenServiceBroker(url, client, clientSecret, apiVersion string) *OpenServiceBroker {
 	return &OpenServiceBroker{
-		url:      url,
-		username: client,
-		password: clientSecret,
+		url:        url,
+		username:   client,
+		password:   clientSecret,
+		apiVersion: apiVersion,
 	}
 }
 
@@ -37,6 +39,7 @@ func (broker *OpenServiceBroker) Catalog() (catalogResp *brokerapi.CatalogRespon
 			return nil, errwrap.Wrapf("Cannot construct HTTP request: {{err}}", err)
 		}
 		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-Broker-Api-Version", broker.apiVersion)
 		req.SetBasicAuth(broker.username, broker.password)
 
 		client := &http.Client{}
@@ -80,6 +83,7 @@ func (broker *OpenServiceBroker) Provision(serviceID, planID, instanceID string)
 		return nil, false, errwrap.Wrapf("Cannot construct HTTP request: {{err}}", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Broker-Api-Version", broker.apiVersion)
 	req.SetBasicAuth(broker.username, broker.password)
 
 	client := &http.Client{}
@@ -136,6 +140,7 @@ func (broker *OpenServiceBroker) Bind(serviceID, planID, instanceID, bindingID s
 		return nil, errwrap.Wrapf("Cannot construct HTTP request: {{err}}", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Broker-Api-Version", broker.apiVersion)
 	req.SetBasicAuth(broker.username, broker.password)
 
 	client := &http.Client{}
@@ -167,6 +172,7 @@ func (broker *OpenServiceBroker) Unbind(serviceID, planID, instanceID, bindingID
 		return errwrap.Wrapf("Cannot construct HTTP request: {{err}}", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Broker-Api-Version", broker.apiVersion)
 	req.SetBasicAuth(broker.username, broker.password)
 
 	client := &http.Client{}
@@ -188,6 +194,7 @@ func (broker *OpenServiceBroker) Deprovision(serviceID, planID, instanceID strin
 		return false, errwrap.Wrapf("Cannot construct HTTP request: {{err}}", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Broker-Api-Version", broker.apiVersion)
 	req.SetBasicAuth(broker.username, broker.password)
 
 	client := &http.Client{}
@@ -211,6 +218,7 @@ func (broker *OpenServiceBroker) LastOperation(serviceID, planID, instanceID str
 		return nil, errwrap.Wrapf("Cannot construct HTTP request: {{err}}", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Broker-Api-Version", broker.apiVersion)
 	req.SetBasicAuth(broker.username, broker.password)
 
 	client := &http.Client{}

--- a/cmd/bind.go
+++ b/cmd/bind.go
@@ -20,7 +20,12 @@ func (c BindOpts) Execute(_ []string) (err error) {
   }
 	instance := Opts.config().FindServiceInstance(instanceNameOrID)
 
-	broker := apiclient.NewOpenServiceBroker(Opts.Broker.URLOpt, Opts.Broker.ClientOpt, Opts.Broker.ClientSecretOpt)
+	broker := apiclient.NewOpenServiceBroker(
+		Opts.Broker.URLOpt,
+		Opts.Broker.ClientOpt,
+		Opts.Broker.ClientSecretOpt,
+		Opts.Broker.APIVersion,
+	)
 
   bindingID := uuid.New()
 	bindingName := fmt.Sprintf("%s-%s", instance.ServiceName, bindingID)

--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -14,7 +14,12 @@ type CatalogOpts struct {
 
 // Execute is callback from go-flags.Commander interface
 func (c CatalogOpts) Execute(_ []string) (err error) {
-	broker := apiclient.NewOpenServiceBroker(Opts.Broker.URLOpt, Opts.Broker.ClientOpt, Opts.Broker.ClientSecretOpt)
+	broker := apiclient.NewOpenServiceBroker(
+		Opts.Broker.URLOpt,
+		Opts.Broker.ClientOpt,
+		Opts.Broker.ClientSecretOpt,
+		Opts.Broker.APIVersion,
+	)
 
 	catalogResp, err := broker.Catalog()
 	if err != nil {

--- a/cmd/deprovision.go
+++ b/cmd/deprovision.go
@@ -22,7 +22,12 @@ func (c DeprovisionOpts) Execute(_ []string) (err error) {
   }
 	instance := Opts.config().FindServiceInstance(instanceNameOrID)
 
-	broker := apiclient.NewOpenServiceBroker(Opts.Broker.URLOpt, Opts.Broker.ClientOpt, Opts.Broker.ClientSecretOpt)
+	broker := apiclient.NewOpenServiceBroker(
+		Opts.Broker.URLOpt,
+		Opts.Broker.ClientOpt,
+		Opts.Broker.ClientSecretOpt,
+		Opts.Broker.APIVersion,
+	)
 	isAsync, err := broker.Deprovision(instance.ServiceID, instance.PlanID, instance.ID)
 	if err != nil {
 		return errwrap.Wrapf("Failed to deprovision service instance {{err}}", err)

--- a/cmd/opts.go
+++ b/cmd/opts.go
@@ -16,6 +16,7 @@ type BrokerOpts struct {
 	URLOpt          string `long:"url"           description:"Open Service Broker URL"                env:"EDEN_BROKER_URL" required:"true"`
 	ClientOpt       string `long:"client"        description:"Override username or UAA client"        env:"EDEN_BROKER_CLIENT" required:"true"`
 	ClientSecretOpt string `long:"client-secret" description:"Override password or UAA client secret" env:"EDEN_BROKER_CLIENT_SECRET" required:"true"`
+	APIVersion      string `long:"api-version"   description:"API version request to pass to backend broker" env:"EDEN_BROKER_API_VERSION" default:"2.13"`
 }
 
 // EdenOpts describes the flags/options for the CLI

--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -19,7 +19,12 @@ type ProvisionOpts struct {
 
 // Execute is callback from go-flags.Commander interface
 func (c ProvisionOpts) Execute(_ []string) (err error) {
-	broker := apiclient.NewOpenServiceBroker(Opts.Broker.URLOpt, Opts.Broker.ClientOpt, Opts.Broker.ClientSecretOpt)
+	broker := apiclient.NewOpenServiceBroker(
+		Opts.Broker.URLOpt,
+		Opts.Broker.ClientOpt,
+		Opts.Broker.ClientSecretOpt,
+		Opts.Broker.APIVersion,
+	)
 
 	service, err := broker.FindServiceByNameOrID(c.ServiceNameOrID)
   if err != nil {

--- a/cmd/unbind.go
+++ b/cmd/unbind.go
@@ -21,7 +21,12 @@ func (c UnbindOpts) Execute(_ []string) (err error) {
 	instance := Opts.config().FindServiceInstance(instanceNameOrID)
 	// TODO: convert c.BindingID into ID if its a name
 
-	broker := apiclient.NewOpenServiceBroker(Opts.Broker.URLOpt, Opts.Broker.ClientOpt, Opts.Broker.ClientSecretOpt)
+	broker := apiclient.NewOpenServiceBroker(
+		Opts.Broker.URLOpt,
+		Opts.Broker.ClientOpt,
+		Opts.Broker.ClientSecretOpt,
+		Opts.Broker.APIVersion,
+	)
 	err = broker.Unbind(instance.ServiceID, instance.PlanID, instance.ID, c.BindingID)
 	if err != nil {
 		return errwrap.Wrapf("Failed to unbind to service instance {{err}}", err)


### PR DESCRIPTION
`eden` requests will provide `X-Broker-Api-Version: 2.13` in its client requests to backend broker API.

Override with `EDEN_BROKER_API_VERSION` or `--api-version` flag.