### PR TITLE
Handle broker provision reponse 200 OK

### DIFF
--- a/apiclient/open_service_broker.go
+++ b/apiclient/open_service_broker.go
@@ -104,7 +104,7 @@ func (broker *OpenServiceBroker) Provision(serviceID, planID, instanceID string)
 	}
 	if resp.StatusCode == http.StatusAccepted {
 		isAsync = true
-	} else if resp.StatusCode == http.StatusCreated {
+	} else if resp.StatusCode == http.StatusCreated || resp.StatusCode == http.StatusOK {
 		isAsync = false
 	} else {
 		errorResp := &brokerapi.ErrorResponse{}


### PR DESCRIPTION
- Spec states that 200 OK is a valid response that signifies the
instance already exists & is fully provisioned.

Signed-off-by: Henry Stanley <hstanley@pivotal.io>