### PR TITLE
Fix ubuntu install commands to sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Interact with any Open Service Broker API to discover/provision/bind/unbind/depr
 For Ubuntu/Debian:
 
 ```shell
-wget -q -O - https://raw.githubusercontent.com/starkandwayne/homebrew-cf/master/public.key | apt-key add -
-echo "deb http://apt.starkandwayne.com stable main" | tee /etc/apt/sources.list.d/starkandwayne.list
-apt-get update
-apt-get install eden
+wget -q -O - https://raw.githubusercontent.com/starkandwayne/homebrew-cf/master/public.key | sudo apt-key add -
+echo "deb http://apt.starkandwayne.com stable main" | sudo tee /etc/apt/sources.list.d/starkandwayne.list
+sudo apt-get update
+sudo apt-get install eden
 ```
 
 For Mac OS using Homebrew:


### PR DESCRIPTION
otherwise, copy/paste is tedious with ubuntu, failing with:

```sh
$echo "deb http://apt.starkandwayne.com stable main" | tee /etc/apt/sources.list.d/starkandwayne.list
tee: /etc/apt/sources.list.d/starkandwayne.list: Permission denied
deb http://apt.starkandwayne.com stable main
```