### PR TITLE
Consider service plan `free` as optional

### DIFF
--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -74,9 +74,12 @@ func (c CatalogOpts) Execute(_ []string) (err error) {
 				planID = plan.ID
 			}
 			/* FIXME service descriptions are ignored */
-			freeOrPaid := "paid"
-			if *plan.Free {
-				freeOrPaid = "free"
+			freeOrPaid := "unspecified"
+			if plan.Free != nil {
+				freeOrPaid = "paid"
+				if *plan.Free {
+					freeOrPaid = "free"
+				}
 			}
 			if previousService == service.Name {
 				table.Row(nil, "~", plan.Name, freeOrPaid, plan.Description)


### PR DESCRIPTION
As per specification `plan.free` is not a required parameter and entirely skipped in json
serialization in the brokerapi implementation. (see omitempty).
Eden will panic while trying to dereference a nil pointer.