### PR TITLE
Add install instructions for FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ For Mac OS using Homebrew:
 brew install starkandwayne/cf/eden
 ```
 
+For FreeBSD using pkg:
+
+```shell
+pkg install eden
+```
+
+For FreeBSD using ports:
+
+```shell
+cd /usr/ports/www/eden
+make install
+```
+
 From source using Golang:
 
 ```shell


### PR DESCRIPTION
Now that there is a [FreeBSD port](https://www.freshports.org/www/eden/) add install instructions for pkg and ports.