### PR TITLE
Implement Update command to send update parameters

### DIFF
--- a/apiclient/interface.go
+++ b/apiclient/interface.go
@@ -6,6 +6,7 @@ type Broker interface {
 	ProvisionAndBind(serviceID, planID string)
 	Bind(serviceID, planID, instanceID, bindingID string)
 	Unbind(serviceID, planID, instanceID, bindingID string)
+	Update(serviceID, planID, instanceID string)
 	Deprovision(serviceID, planID, instanceID string)
 	LastOperation(serviceID, planID, instanceID string)
 }

--- a/cmd/opts.go
+++ b/cmd/opts.go
@@ -44,6 +44,7 @@ type EdenOpts struct {
 	Provision   ProvisionOpts   `command:"provision" alias:"p" description:"Create new service instance"`
 	Bind        BindOpts        `command:"bind" alias:"b" description:"Generate credentials for service instance"`
 	Unbind      UnbindOpts      `command:"unbind" alias:"u" description:"Remove credentials for service instance"`
+	Update      UpdateOpts      `command:"update" alias:"U" description:"Update service instance"`
 	Deprovision DeprovisionOpts `command:"deprovision" alias:"d" description:"Destroy service instance"`
 
 	// Local data commands

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/errwrap"
+	"github.com/pivotal-cf/brokerapi"
+	"github.com/starkandwayne/eden/apiclient"
+)
+
+// UpdateOpts represents the 'update' command
+type UpdateOpts struct {
+	Parameters      string `short:"P" long:"parameters" description:"parameters in json format"`
+}
+
+// Execute is callback from go-flags.Commander interface
+func (c UpdateOpts) Execute(_ []string) (err error) {
+	instanceNameOrID := Opts.Instance.NameOrID
+	if instanceNameOrID == "" {
+		return fmt.Errorf("update command requires --instance [NAME|GUID], or $SB_INSTANCE")
+	}
+	instance := Opts.config().FindServiceInstance(instanceNameOrID)
+
+	broker := apiclient.NewOpenServiceBroker(
+		Opts.Broker.URLOpt,
+		Opts.Broker.ClientOpt,
+		Opts.Broker.ClientSecretOpt,
+		Opts.Broker.APIVersion,
+	)
+
+	var parameters json.RawMessage
+	if len(c.Parameters) > 0 {
+		var input []byte
+		if strings.HasPrefix(c.Parameters, "@") {
+			input, err = ioutil.ReadFile(c.Parameters[1:])
+			if err != nil {
+				return errwrap.Wrapf("Could not read file: {{err}}", err)
+			}
+		} else {
+			input = []byte(c.Parameters)
+		}
+		if err := json.Unmarshal(input, &parameters); err != nil {
+			return errwrap.Wrapf("Could not unmarshal parameters: {{err}}", err)
+		}
+	}
+	updateResp, isAsync, err := broker.Update(instance.ServiceID, instance.PlanID, instance.ID, parameters)
+	if err != nil {
+		return errwrap.Wrapf("Failed to update service instance {{err}}", err)
+	}
+
+	fmt.Printf("update:   name: %s\n", instanceNameOrID)
+	if isAsync {
+		fmt.Println("update:   in-progress")
+		// TODO: don't pollute brokerapi back into this level
+		lastOpResp := &brokerapi.LastOperationResponse{State: brokerapi.InProgress}
+		for lastOpResp.State == brokerapi.InProgress {
+			time.Sleep(5 * time.Second)
+			lastOpResp, err = broker.LastOperation(instance.ServiceID, instance.PlanID, instance.ID, updateResp.OperationData)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err.Error())
+				os.Exit(1)
+			}
+			fmt.Printf("update:   %s - %s\n", lastOpResp.State, lastOpResp.Description)
+		}
+	}
+
+	fmt.Println("update:   done")
+	return
+}


### PR DESCRIPTION
This PR implements a simple Update command that allows you to send parameters only. It will not allow for updating the plan in use at the moment. This is useful for services that allow you to customize the way they behave by doing an update (eg, an RDS broker that allows you to reboot the database)